### PR TITLE
Add share answer flow to feed posts

### DIFF
--- a/src/app/[locale]/chat/onboarding/_components/post-message.test.tsx
+++ b/src/app/[locale]/chat/onboarding/_components/post-message.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@/test-utils/test-utils';
+import { fireEvent, render, screen } from '@/test-utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import PostMessage from './post-message';
 
@@ -132,6 +132,62 @@ describe('PostMessage', () => {
     await user.click(shareButton);
 
     expect(mockOnShare).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables interaction buttons when the post is disabled', async () => {
+    const mockOnLike = jest.fn();
+    const mockOnDislike = jest.fn();
+    const mockOnComment = jest.fn();
+    const mockOnShare = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PostMessage
+        {...defaultProps}
+        isDisabled
+        onLike={mockOnLike}
+        onDislike={mockOnDislike}
+        onComment={mockOnComment}
+        onShare={mockOnShare}
+      />
+    );
+
+    const likeButton = screen.getByLabelText('Like');
+    const dislikeButton = screen.getByLabelText('Dislike');
+    const commentButton = screen.getByLabelText('Comment');
+    const shareButton = screen.getByLabelText('Share');
+
+    expect(likeButton).toBeDisabled();
+    expect(dislikeButton).toBeDisabled();
+    expect(commentButton).toBeDisabled();
+    expect(shareButton).toBeDisabled();
+
+    await user.click(likeButton);
+    await user.click(dislikeButton);
+    await user.click(commentButton);
+    await user.click(shareButton);
+
+    expect(mockOnLike).not.toHaveBeenCalled();
+    expect(mockOnDislike).not.toHaveBeenCalled();
+    expect(mockOnComment).not.toHaveBeenCalled();
+    expect(mockOnShare).not.toHaveBeenCalled();
+  });
+
+  it('keeps action pointer events from bubbling to the carousel', () => {
+    const mockParentPointerDown = jest.fn();
+
+    render(
+      <div onPointerDown={mockParentPointerDown}>
+        <PostMessage {...defaultProps} />
+      </div>
+    );
+
+    fireEvent.pointerDown(screen.getByLabelText('Like'));
+    fireEvent.pointerDown(screen.getByLabelText('Dislike'));
+    fireEvent.pointerDown(screen.getByLabelText('Comment'));
+    fireEvent.pointerDown(screen.getByLabelText('Share'));
+
+    expect(mockParentPointerDown).not.toHaveBeenCalled();
   });
 
   it('renders all interaction buttons', () => {

--- a/src/app/[locale]/chat/onboarding/_components/post-message.tsx
+++ b/src/app/[locale]/chat/onboarding/_components/post-message.tsx
@@ -46,6 +46,15 @@ export default function PostMessage({
   onComment,
   onShare,
 }: PostMessageProps) {
+  const stopCarouselDrag = (event: React.PointerEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
+  const likeButtonDisabled = isDisabled || likeDisabled;
+  const dislikeButtonDisabled = isDisabled || dislikeDisabled;
+  const commentButtonDisabled = isDisabled || commentDisabled;
+  const shareButtonDisabled = isDisabled || shareDisabled;
+
   return (
     <article className={cn("w-full rounded-lg border border-[#E8E9ED] bg-white p-4 shadow-sm", isDisabled ? 'opacity-50 cursor-not-allowed' : '', className)}>
       {/* Header with avatar, name, handle, and dropdown */}
@@ -96,17 +105,19 @@ export default function PostMessage({
         <div className="flex items-center gap-4">
           <button
             onClick={onLike}
-            disabled={likeDisabled}
-            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", likeDisabled ? 'opacity-50 cursor-not-allowed' : '')}
+            onPointerDown={stopCarouselDrag}
+            disabled={likeButtonDisabled}
+            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", likeButtonDisabled ? 'opacity-50 cursor-not-allowed' : '')}
             aria-label="Like"
             type="button"
           >
             <ThumbsUp className={likeClassName} size={20} strokeWidth={2} aria-hidden="true" />
           </button>
           <button
-            disabled={dislikeDisabled}
+            disabled={dislikeButtonDisabled}
             onClick={onDislike}
-            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", dislikeDisabled ? 'opacity-50 cursor-not-allowed' : '')}
+            onPointerDown={stopCarouselDrag}
+            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", dislikeButtonDisabled ? 'opacity-50 cursor-not-allowed' : '')}
             aria-label="Dislike"
             type="button"
           >
@@ -115,18 +126,20 @@ export default function PostMessage({
         </div>
         <div className="flex items-center gap-4">
           <button
-            disabled={commentDisabled}
+            disabled={commentButtonDisabled}
             onClick={onComment}
-            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", commentDisabled ? 'opacity-50 cursor-not-allowed' : '')}
+            onPointerDown={stopCarouselDrag}
+            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", commentButtonDisabled ? 'opacity-50 cursor-not-allowed' : '')}
             aria-label="Comment"
             type="button"
           >
             <MessageCircle className={commentClassName} size={20} strokeWidth={2} aria-hidden="true" />
           </button>
           <button
-            disabled={shareDisabled}
+            disabled={shareButtonDisabled}
             onClick={onShare}
-            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", shareDisabled ? 'opacity-50 cursor-not-allowed' : '')}
+            onPointerDown={stopCarouselDrag}
+            className={cn("flex items-center gap-1 text-(--color-ifrc-blue)/70 transition-colors hover:text-(--color-ifrc-blue)", shareButtonDisabled ? 'opacity-50 cursor-not-allowed' : '')}
             aria-label="Share"
             type="button"
           >

--- a/src/components/content-carousel-items.tsx
+++ b/src/components/content-carousel-items.tsx
@@ -3,12 +3,13 @@
 import { CarouselContent, CarouselItem } from "@/components/ui/carousel";
 import LikeDislikePostMessage from '@/components/newfeeds/like-dislike-post-message';
 import { LikeDislikeContent } from '@/contents/en';
+import { GameAnswer } from '@/lib/use-game-store';
 
 interface ContentCarouselItemsProps {
   contentList: LikeDislikeContent[];
-  getAnswer: (postId: string) => 'like' | 'dislike' | null | undefined;
+  getAnswer: (postId: string) => GameAnswer | null | undefined;
   isPostDisabled: (postId: string) => boolean;
-  onAnswer: (postId: string, answer: 'like' | 'dislike') => void;
+  onAnswer: (postId: string, answer: GameAnswer) => void;
 }
 
 export default function ContentCarouselItems({
@@ -36,6 +37,7 @@ export default function ContentCarouselItems({
               correctAnswer={likeDislikeContent.correctAnswer} 
               onLike={(postId) => onAnswer(postId, 'like')} 
               onDislike={(postId) => onAnswer(postId, 'dislike')}
+              onShare={(postId) => onAnswer(postId, 'share')}
               isDisabled={isDisabled}
             />
           </CarouselItem>

--- a/src/components/home-content.test.tsx
+++ b/src/components/home-content.test.tsx
@@ -172,6 +172,7 @@ jest.mock('./newfeeds/like-dislike-post-message', () => {
     correctAnswer,
     onLike,
     onDislike,
+    onShare,
   }: any) {
     return (
       <div data-testid={`post-${postId}`}>
@@ -182,6 +183,9 @@ jest.mock('./newfeeds/like-dislike-post-message', () => {
         </button>
         <button data-testid={`dislike-${postId}`} onClick={() => onDislike?.(postId)}>
           Dislike
+        </button>
+        <button data-testid={`share-${postId}`} onClick={() => onShare?.(postId)}>
+          Share
         </button>
       </div>
     );
@@ -211,6 +215,39 @@ jest.mock('./chat-content', () => {
   return function MockChatContent() {
     return <div data-testid="chat-content">Chat Content</div>;
   };
+});
+
+Object.defineProperty(global, 'ResizeObserver', {
+  writable: true,
+  value: jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  })),
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+Object.defineProperty(global, 'IntersectionObserver', {
+  writable: true,
+  value: jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+    takeRecords: jest.fn(() => []),
+  })),
 });
 
 const mockSetCredibility = jest.fn();
@@ -281,6 +318,28 @@ describe('HomeContent', () => {
     await user.click(likeButton);
 
     expect(mockSetAnswer).toHaveBeenCalledWith('1', 'like');
+    expect(mockSetCredibility).not.toHaveBeenCalled();
+  });
+
+  it('decreases credibility when sharing a misleading post', async () => {
+    const user = userEvent.setup();
+    render(<HomeContent />);
+
+    const shareButton = screen.getByTestId('share-2');
+    await user.click(shareButton);
+
+    expect(mockSetAnswer).toHaveBeenCalledWith('2', 'share');
+    expect(mockSetCredibility).toHaveBeenCalledWith(75);
+  });
+
+  it('maintains credibility when sharing a trustworthy post', async () => {
+    const user = userEvent.setup();
+    render(<HomeContent />);
+
+    const shareButton = screen.getByTestId('share-1');
+    await user.click(shareButton);
+
+    expect(mockSetAnswer).toHaveBeenCalledWith('1', 'share');
     expect(mockSetCredibility).not.toHaveBeenCalled();
   });
 

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ChatContent from '@/components/chat-content';
 import { useTranslations } from 'next-intl';
 import { useLocale } from 'next-intl';
@@ -9,7 +9,7 @@ import { useLocalStorage } from '@/lib/use-local-storage';
 import PrebunkingModal from '@/components/newfeeds/prebunking-modal';
 import CONTENTS from '@/contents';
 import { ContentType, LikeDislikeContent } from '@/contents/en';
-import { createGameStore } from '@/lib/use-game-store';
+import { createGameStore, GameAnswer } from '@/lib/use-game-store';
 import { useCredibilityStore } from '@/lib/use-credibility-store';
 import ContentCarouselItems from '@/components/content-carousel-items';
 
@@ -27,12 +27,15 @@ export default function HomeContent() {
   const { content, contentList } = CONTENTS[locale as keyof typeof CONTENTS];
   const [modalPostId, setModalPostId] = useState<string | null>(null);
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
-  const useGameStore = createGameStore({
-    answers: {},
-    currentQuestionIndex: 0,
-    questions: contentList.map(item => item.id),
-    questionStore: content,
-  });
+  const useGameStore = useMemo(
+    () => createGameStore({
+      answers: {},
+      currentQuestionIndex: 0,
+      questions: contentList.map(item => item.id),
+      questionStore: content,
+    }),
+    [content, contentList]
+  );
   
   const { 
     getAnswer, 
@@ -58,7 +61,15 @@ export default function HomeContent() {
   };
 
 
-  const handleOnAnswer = (postId: string, answer: 'like' | 'dislike') => {
+  const isCorrectAnswer = (answer: GameAnswer, contentItem: LikeDislikeContent) => {
+    if (answer === 'share') {
+      return contentItem.correctAnswer === 'like';
+    }
+
+    return answer === contentItem.correctAnswer;
+  };
+
+  const handleOnAnswer = (postId: string, answer: GameAnswer) => {
     // Only allow answer if post is not already answered
     if (!isAnswered(postId)) {
       setAnswer(postId, answer);
@@ -66,7 +77,7 @@ export default function HomeContent() {
       // Find the content item to check correctness
       const contentItem = contentList.find(item => item.id === postId) as LikeDislikeContent | undefined;
       if (contentItem && contentItem.type === ContentType.LIKE_DISLIKE) {
-        const isCorrect = answer === contentItem.correctAnswer;
+        const isCorrect = isCorrectAnswer(answer, contentItem);
         
         // Decrease credibility if incorrect
         if (!isCorrect) {
@@ -118,7 +129,7 @@ export default function HomeContent() {
         const modalAnswer = getAnswer(modalPostId);
         if (!modalAnswer) return null;
         
-        const isCorrect = modalAnswer === contentItem.correctAnswer;
+        const isCorrect = isCorrectAnswer(modalAnswer, contentItem);
         const reasonContent = isCorrect 
           ? contentItem.whyCorrectAnswer.content 
           : contentItem.whyIncorrectAnswer.content;

--- a/src/components/newfeeds/like-dislike-post-message.test.tsx
+++ b/src/components/newfeeds/like-dislike-post-message.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, act } from '@/test-utils/test-utils';
+import { render, screen } from '@/test-utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import LikeDislikePostMessage from './like-dislike-post-message';
 
@@ -11,12 +11,14 @@ jest.mock('@/app/[locale]/chat/onboarding/_components/post-message', () => {
     content,
     onLike,
     onDislike,
+    onShare,
     likeDisabled,
     dislikeDisabled,
     commentDisabled,
     shareDisabled,
     likeClassName,
     dislikeClassName,
+    shareClassName,
   }: any) {
     return (
       <div data-testid="post-message">
@@ -50,7 +52,9 @@ jest.mock('@/app/[locale]/chat/onboarding/_components/post-message', () => {
         </button>
         <button
           data-testid="share-button"
+          onClick={onShare}
           disabled={shareDisabled}
+          className={shareClassName}
           aria-label="Share"
         >
           Share
@@ -111,7 +115,7 @@ describe('LikeDislikePostMessage', () => {
     },
     content: <div>Test post content</div>,
     correctAnswer: 'like' as const,
-    answer: null as 'like' | 'dislike' | null,
+    answer: null as 'like' | 'dislike' | 'share' | null,
   };
 
   beforeEach(() => {
@@ -144,14 +148,14 @@ describe('LikeDislikePostMessage', () => {
     expect(dislikeButton).toBeDisabled();
   });
 
-  it('passes commentDisabled and shareDisabled as true', () => {
+  it('passes commentDisabled as true and shareDisabled as false when not answered', () => {
     render(<LikeDislikePostMessage {...defaultProps} />);
 
     const commentButton = screen.getByTestId('comment-button');
     const shareButton = screen.getByTestId('share-button');
 
     expect(commentButton).toBeDisabled();
-    expect(shareButton).toBeDisabled();
+    expect(shareButton).not.toBeDisabled();
   });
 
   it('calls onLike when like button is clicked and not answered', async () => {
@@ -178,6 +182,18 @@ describe('LikeDislikePostMessage', () => {
     expect(mockOnDislike).toHaveBeenCalledWith('post-123');
   });
 
+  it('calls onShare when share button is clicked and not answered', async () => {
+    const mockOnShare = jest.fn();
+    const user = userEvent.setup();
+    render(<LikeDislikePostMessage {...defaultProps} answer={null} onShare={mockOnShare} />);
+
+    const shareButton = screen.getByTestId('share-button');
+    await user.click(shareButton);
+
+    expect(mockOnShare).toHaveBeenCalledTimes(1);
+    expect(mockOnShare).toHaveBeenCalledWith('post-123');
+  });
+
   it('does not call onLike if post is already answered', async () => {
     const mockOnLike = jest.fn();
     const user = userEvent.setup();
@@ -187,6 +203,17 @@ describe('LikeDislikePostMessage', () => {
     await user.click(likeButton);
 
     expect(mockOnLike).not.toHaveBeenCalled();
+  });
+
+  it('does not call onShare if post is already answered', async () => {
+    const mockOnShare = jest.fn();
+    const user = userEvent.setup();
+    render(<LikeDislikePostMessage {...defaultProps} answer="share" onShare={mockOnShare} />);
+
+    const shareButton = screen.getByTestId('share-button');
+    await user.click(shareButton);
+
+    expect(mockOnShare).not.toHaveBeenCalled();
   });
 
 
@@ -224,6 +251,20 @@ describe('LikeDislikePostMessage', () => {
     const dislikeButton = screen.getByTestId('dislike-button');
     expect(dislikeButton).not.toHaveClass('fill-(--color-dunder-green)');
     expect(dislikeButton).not.toHaveClass('fill-(--color-dunder-red)');
+  });
+
+  it('applies correct color class to share button when sharing a trustworthy post', () => {
+    render(<LikeDislikePostMessage {...defaultProps} correctAnswer="like" answer="share" />);
+
+    const shareButton = screen.getByTestId('share-button');
+    expect(shareButton).toHaveClass('fill-(--color-dunder-green)');
+  });
+
+  it('applies incorrect color class to share button when sharing a misleading post', () => {
+    render(<LikeDislikePostMessage {...defaultProps} correctAnswer="dislike" answer="share" />);
+
+    const shareButton = screen.getByTestId('share-button');
+    expect(shareButton).toHaveClass('fill-(--color-dunder-red)');
   });
 
 

--- a/src/components/newfeeds/like-dislike-post-message.tsx
+++ b/src/components/newfeeds/like-dislike-post-message.tsx
@@ -2,14 +2,16 @@
 
 import PostMessage, { PostMessageProps } from '@/app/[locale]/chat/onboarding/_components/post-message';
 import { User } from '@/contents/en';
+import { GameAnswer } from '@/lib/use-game-store';
 
-export interface LikeDislikePostMessageProps extends Omit<PostMessageProps, 'likeDisabled' | 'dislikeDisabled' | 'commentDisabled' | 'shareDisabled' | 'onLike' | 'onDislike'> {
+export interface LikeDislikePostMessageProps extends Omit<PostMessageProps, 'likeDisabled' | 'dislikeDisabled' | 'commentDisabled' | 'shareDisabled' | 'onLike' | 'onDislike' | 'onShare'> {
   postId: string;
-  answer: 'like' | 'dislike' | null | undefined;
+  answer: GameAnswer | null | undefined;
   correctAnswer: 'like' | 'dislike';
   user: User;
   onLike?: (postId: string) => void;
   onDislike?: (postId: string) => void;
+  onShare?: (postId: string) => void;
 }
 
 const colors = {
@@ -22,6 +24,7 @@ export default function LikeDislikePostMessage({
   user,
   onLike,
   onDislike,
+  onShare,
   answer,
   correctAnswer,
   mediaUrl,
@@ -32,7 +35,9 @@ export default function LikeDislikePostMessage({
   // Use answer from props (passed from parent)
   const currentAnswer = answer ?? null;
   const hasAnswered = currentAnswer !== null && currentAnswer !== undefined;
-  const isCorrect = currentAnswer === correctAnswer;
+  const isCorrect = currentAnswer === 'share'
+    ? correctAnswer === 'like'
+    : currentAnswer === correctAnswer;
 
   const handleLike = () => {
     if (!hasAnswered) {
@@ -46,11 +51,20 @@ export default function LikeDislikePostMessage({
     }
   };
 
+  const handleShare = () => {
+    if (!hasAnswered) {
+      onShare?.(postId);
+    }
+  };
+
   // Apply background fill only to the button that was clicked
   const likeClassName = hasAnswered && currentAnswer === 'like'
     ? (isCorrect ? colors.correctClass : colors.incorrectClass)
     : '';
   const dislikeClassName = hasAnswered && currentAnswer === 'dislike'
+    ? (isCorrect ? colors.correctClass : colors.incorrectClass)
+    : '';
+  const shareClassName = hasAnswered && currentAnswer === 'share'
     ? (isCorrect ? colors.correctClass : colors.incorrectClass)
     : '';
 
@@ -60,12 +74,14 @@ export default function LikeDislikePostMessage({
       content={content}
       onLike={handleLike}
       onDislike={handleDislike}
+      onShare={handleShare}
       likeClassName={likeClassName}
       dislikeClassName={dislikeClassName}
+      shareClassName={shareClassName}
       likeDisabled={hasAnswered}
       dislikeDisabled={hasAnswered}
       commentDisabled={true}
-      shareDisabled={true}
+      shareDisabled={hasAnswered}
       mediaUrl={mediaUrl}
       mediaType={mediaType}
       {...postMessageProps}

--- a/src/lib/use-game-store.ts
+++ b/src/lib/use-game-store.ts
@@ -3,16 +3,18 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { STORAGE_KEYS } from './local-storage';
 import { ContentBase, ContentId } from '@/contents/en';
 
+export type GameAnswer = 'like' | 'dislike' | 'share';
+
 interface GameState {
-  answers: Record<string, 'like' | 'dislike'>;
+  answers: Record<string, GameAnswer>;
   currentQuestionIndex: number;
   questions: Array<ContentId>;
   questionStore: Record<ContentId, ContentBase>;
 }
 
 interface GameStore extends GameState {
-  setAnswer: (postId: string, answer: 'like' | 'dislike') => void;
-  getAnswer: (postId: string) => 'like' | 'dislike' | null;
+  setAnswer: (postId: string, answer: GameAnswer) => void;
+  getAnswer: (postId: string) => GameAnswer | null;
   isAnswered: (postId: string) => boolean;
   isCurrentQuestionAnswered: (contentList: Array<{ id: string }>) => boolean;
   isPostDisabled: (postId: string) => boolean;
@@ -34,7 +36,7 @@ export const createGameStore = (initialState?: Partial<GameState>) => create<Gam
         const currentQuestion = state.questions[state.currentQuestionIndex];
         return currentQuestion !== postId;
       },
-      setAnswer: (postId: string, answer: 'like' | 'dislike') => {
+      setAnswer: (postId: string, answer: GameAnswer) => {
         const state = get();
         // Only set answer if not already answered (immutability)
         if (!state.answers[postId]) {


### PR DESCRIPTION
- Enable share as an answer option alongside like and dislike.
- Reuse the existing prebunking modal to show share explanations.
- Score sharing trustworthy posts as correct and misleading posts as incorrect.
- Prevent carousel drag handling from blocking answer button clicks.
- Add tests for share answers, disabled states, and button interactions.