### PR TITLE
feat: add Alex chat page with MCQ fact-checking question

### DIFF
--- a/src/app/[locale]/chat/_constants/users.tsx
+++ b/src/app/[locale]/chat/_constants/users.tsx
@@ -1,6 +1,7 @@
 import { User, UserId } from "@/contents/en";
 import EchoAvatar from "../onboarding/_icons/echo-avatar";
 import PaulaAvatar from "../onboarding/_icons/paula-avatar";
+import AlexAvatar from "../onboarding/_icons/alex-avatar";
 
 export const CHAT_USERS: Record<UserId, User> = {
   user: {
@@ -15,6 +16,13 @@ export const CHAT_USERS: Record<UserId, User> = {
     handle: '@paula',
     name: 'Paula',
     avatar: <PaulaAvatar />,
+    isUser: false,
+  },
+  alex: {
+    id: 'alex',
+    handle: '@alex',
+    name: 'Alex',
+    avatar: <AlexAvatar />,
     isUser: false,
   },
   echo: {

--- a/src/app/[locale]/chat/alex/page.tsx
+++ b/src/app/[locale]/chat/alex/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { content, ContentType, MCQContent } from '@/contents/en';
+import { useCredibilityStore } from '@/lib/use-credibility-store';
+import ChatHeadline from '../onboarding/_components/chat-headline';
+import BotTextMessage from '../onboarding/_components/bot-text-message';
+import UserTextMessage from '../onboarding/_components/user-text-message';
+import OptionButton from '../onboarding/_components/option-button';
+import { CHAT_USERS } from '../_constants/users';
+
+const ALEX_QUESTION = content['mcq-1'];
+const CORRECT_ANSWER_POINTS = 5;
+
+function BotRichMessage({
+  senderAvatar,
+  senderName,
+  children,
+}: {
+  senderAvatar?: React.ReactNode;
+  senderName: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex w-full justify-start gap-3">
+      {senderAvatar && <div className="flex items-end justify-end">{senderAvatar}</div>}
+      <div className="w-full flex-col gap-1 md:max-w-[70%]">
+        <div className="flex justify-end">
+          <div className="flex rounded-r-2xl rounded-tl-2xl border border-[#2979FF] bg-[#2979FF]/10 px-4 py-3 text-black">
+            <div className="space-y-3 text-sm leading-relaxed">{children}</div>
+          </div>
+        </div>
+        <span className="text-xs font-medium text-[#2979FF]">{senderName}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function AlexChatPage() {
+  const t = useTranslations('chat.alex');
+  const point = useCredibilityStore((state) => state.point);
+  const setPoint = useCredibilityStore((state) => state.setPoint);
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+
+  const question = ALEX_QUESTION?.type === ContentType.MCQ ? (ALEX_QUESTION as MCQContent) : null;
+  const selectedOption = question?.options.find((o) => o.id === selectedOptionId) ?? null;
+  const isCorrect = selectedOptionId === question?.correctOptionId;
+
+  const handleOptionClick = (optionId: string) => {
+    if (!question || selectedOptionId) return;
+    setSelectedOptionId(optionId);
+    if (optionId === question.correctOptionId) setPoint(point + CORRECT_ANSWER_POINTS);
+  };
+
+  if (!question) return null;
+
+  return (
+    <div className="mx-auto flex flex-col md:px-4 md:pt-6">
+      <ChatHeadline name={CHAT_USERS.alex.name} />
+      <div className="mx-auto flex h-[calc(100vh-10rem)] w-full max-w-md flex-col">
+        <div className="flex-1 space-y-4 overflow-y-auto px-4 py-6">
+          <BotTextMessage
+            senderName={CHAT_USERS.alex.name}
+            senderAvatar={CHAT_USERS.alex.avatar}
+            displayText={t('greeting')}
+          />
+          <BotRichMessage senderName={CHAT_USERS.alex.name} senderAvatar={CHAT_USERS.alex.avatar}>
+            {question.post.content}
+          </BotRichMessage>
+
+          {selectedOption && <UserTextMessage displayText={selectedOption.label} />}
+
+          {selectedOption && (
+            <>
+              <BotTextMessage
+                senderName={CHAT_USERS.alex.name}
+                senderAvatar={CHAT_USERS.alex.avatar}
+                displayText={
+                  isCorrect
+                    ? t('correctReply', { points: CORRECT_ANSWER_POINTS })
+                    : t('incorrectReply')
+                }
+              />
+              <BotRichMessage senderName={CHAT_USERS.alex.name} senderAvatar={CHAT_USERS.alex.avatar}>
+                {isCorrect ? question.whyCorrectAnswer.content : question.whyIncorrectAnswer.content}
+              </BotRichMessage>
+            </>
+          )}
+        </div>
+
+        {!selectedOption && (
+          <div className="border-t border-[#E8E9ED] bg-white px-4 py-4 md:pb-4">
+            <div className="mb-3 text-sm font-medium text-[#0D1B3E]">{t('chooseAnswer')}</div>
+            <div className="mx-auto flex max-w-2xl flex-col gap-3">
+              {question.options.map((option) => (
+                <OptionButton
+                  key={option.id}
+                  id={option.id}
+                  displayText={option.label}
+                  onClick={() => handleOptionClick(option.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/chat/page.tsx
+++ b/src/app/[locale]/chat/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/routing';
 import PaulaAvatar from './onboarding/_icons/paula-avatar';
 import AlexAvatar from './onboarding/_icons/alex-avatar';
 
@@ -8,12 +9,17 @@ interface ChatListItemProps {
   name: string;
   avatar: React.ReactNode;
   newMessageText: string;
+  href: '/chat/onboarding' | '/chat/alex';
   hasNewMessage?: boolean;
 }
 
-function ChatListItem({ name, avatar, newMessageText, hasNewMessage = false }: ChatListItemProps) {  
+function ChatListItem({ name, avatar, newMessageText, href, hasNewMessage = false }: ChatListItemProps) {
   return (
-    <div className="flex items-center justify-between w-full rounded-3xl border-1 border-dashed border-[#011E41] bg-[#E4EAF3] px-6 py-4 min-h-[60px]">
+    <Link
+      href={href}
+      className="flex min-h-[60px] w-full items-center justify-between rounded-3xl border-1 border-dashed border-[#011E41] bg-[#E4EAF3] px-6 py-4 transition-colors hover:bg-[#D8E1EE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#011E41]"
+      aria-label={name}
+    >
       <div className="flex items-center gap-3">
         <span className="h-10 w-10 flex items-center justify-center">
           {avatar}
@@ -26,7 +32,7 @@ function ChatListItem({ name, avatar, newMessageText, hasNewMessage = false }: C
           <span className="text-sm font-medium text-red-600">{newMessageText}</span>
         </div>
       )}
-    </div>
+    </Link>
   );
 }
 
@@ -38,8 +44,20 @@ export default function ChatPage() {
       <div className='flex justify-center items-center text-2xl font-bold text-[#011E41] pt-4'>{t('title')}</div>
       <div className="mx-auto flex items-start h-[calc(100vh-10rem)] max-w-md flex-col w-full">
         <div className="w-full space-y-4 pt-4">
-          <ChatListItem name={t('paula')} avatar={<PaulaAvatar />} newMessageText={t('newMessage')} hasNewMessage={true} />
-          <ChatListItem name={t('alex')} avatar={<AlexAvatar />} newMessageText={t('newMessage')} hasNewMessage={false} />
+          <ChatListItem
+            name={t('paula')}
+            avatar={<PaulaAvatar />}
+            newMessageText={t('newMessage')}
+            href="/chat/onboarding"
+            hasNewMessage={true}
+          />
+          <ChatListItem
+            name={t('alex')}
+            avatar={<AlexAvatar />}
+            newMessageText={t('newMessage')}
+            href="/chat/alex"
+            hasNewMessage={false}
+          />
         </div>
       </div>
     </div>

--- a/src/contents/en/index.tsx
+++ b/src/contents/en/index.tsx
@@ -1,6 +1,13 @@
 import EchoAvatar from "@/app/[locale]/chat/onboarding/_icons/echo-avatar";
 import PaulaAvatar from "@/app/[locale]/chat/onboarding/_icons/paula-avatar";
 
+// MCQ content imports
+import Mcq1Question from "./post/mcq-1-question.md";
+import Mcq1WhyCorrectTitle from "./post/mcq-1-why-correct-title.md";
+import Mcq1WhyCorrectContent from "./post/mcq-1-why-correct-content.md";
+import Mcq1WhyIncorrectTitle from "./post/mcq-1-why-incorrect-title.md";
+import Mcq1WhyIncorrectContent from "./post/mcq-1-why-incorrect-content.md";
+
 // Post content imports
 import Content1Post from "./post/content-1-post.md";
 import Content2Post from "./post/content-2-post.md";
@@ -59,6 +66,7 @@ export type ContentId = string;
 export enum ContentType {
   LIKE_DISLIKE = 'like_dislike',
   SHARE = 'share',
+  MCQ = 'mcq',
 }
 
 export interface ContentBase {
@@ -70,6 +78,26 @@ export interface LikeDislikeContent extends ContentBase {
   type: ContentType.LIKE_DISLIKE;
   post: Post;
   correctAnswer: 'like' | 'dislike';
+  whyCorrectAnswer: {
+    title: React.ReactNode;
+    content: React.ReactNode;
+  };
+  whyIncorrectAnswer: {
+    title: React.ReactNode;
+    content: React.ReactNode;
+  };
+}
+
+export interface MCQOption {
+  id: string;
+  label: string;
+}
+
+export interface MCQContent extends ContentBase {
+  type: ContentType.MCQ;
+  post: Post;
+  options: MCQOption[];
+  correctOptionId: string;
   whyCorrectAnswer: {
     title: React.ReactNode;
     content: React.ReactNode;
@@ -95,7 +123,7 @@ export interface ShareContent extends ContentBase {
 
 export type UserId = string;
 
-export type Content = LikeDislikeContent | ShareContent;
+export type Content = LikeDislikeContent | ShareContent | MCQContent;
 
 export const users: Record<UserId, User> = {
   'paula': {
@@ -221,6 +249,30 @@ export const content: Record<ContentId, Content> = {
     whyIncorrectAnswer: {
       title: <Content5WhyIncorrectTitle />,
       content: <Content5WhyIncorrectContent />,
+    },
+  },
+  'mcq-1': {
+    id: 'mcq-1',
+    type: ContentType.MCQ,
+    post: {
+      id: 'mcq-1',
+      user: users['echo'],
+      content: <Mcq1Question />,
+    },
+    options: [
+      { id: 'a', label: "That's huge if true! Yes, let's share it, so people know!" },
+      { id: 'b', label: 'Wait! Something seems off!' },
+      { id: 'c', label: 'Wait! Something seems off about this post' },
+      { id: 'd', label: 'Wait! I should fact-check this before sharing' },
+    ],
+    correctOptionId: 'b',
+    whyCorrectAnswer: {
+      title: <Mcq1WhyCorrectTitle />,
+      content: <Mcq1WhyCorrectContent />,
+    },
+    whyIncorrectAnswer: {
+      title: <Mcq1WhyIncorrectTitle />,
+      content: <Mcq1WhyIncorrectContent />,
     },
   },
 }

--- a/src/contents/en/post/mcq-1-question.md
+++ b/src/contents/en/post/mcq-1-question.md
@@ -1,0 +1,1 @@
+**ALERT!** The UN has just revealed that global carbon emissions have reached 59.3 gigatonnes in 2025 - the highest ever recorded. Immediate action is needed! Share this with all your friends to help stop climate disaster!

--- a/src/contents/en/post/mcq-1-why-correct-content.md
+++ b/src/contents/en/post/mcq-1-why-correct-content.md
@@ -1,0 +1,7 @@
+This post is using **Cherry-Picking**
+
+It selects one isolated cold weather event to disprove a long-term global trend.
+
+Weather is not the same as Climate. Don't let isolated incidents distract from long-term data in the World Disasters Report.
+
+See the IFRC data on increasing heatwave trends.

--- a/src/contents/en/post/mcq-1-why-correct-title.md
+++ b/src/contents/en/post/mcq-1-why-correct-title.md
@@ -1,0 +1,1 @@
+# Hold on! That's misleading!

--- a/src/contents/en/post/mcq-1-why-incorrect-content.md
+++ b/src/contents/en/post/mcq-1-why-incorrect-content.md
@@ -1,0 +1,7 @@
+This post is using **Cherry-Picking**
+
+It selects one isolated cold weather event to disprove a long-term global trend.
+
+Weather is not the same as Climate. Don't let isolated incidents distract from long-term data in the World Disasters Report.
+
+See the IFRC data on increasing heatwave trends.

--- a/src/contents/en/post/mcq-1-why-incorrect-title.md
+++ b/src/contents/en/post/mcq-1-why-incorrect-title.md
@@ -1,0 +1,1 @@
+# Hold on! That's misleading!

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -38,6 +38,14 @@ export const routing = defineRouting({
       zh: '/聊天/上手',
       ar: '/دردشة/تعريف',
     },
+    '/chat/alex': {
+      en: '/chat/alex',
+      es: '/chat/alex',
+      fr: '/discussion/alex',
+      ru: '/чат/alex',
+      zh: '/聊天/alex',
+      ar: '/دردشة/alex',
+    },
     '/analytics': {
       en: '/analytics',
       es: '/analitica',

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -36,6 +36,12 @@
       "alex": "Alex",
       "newMessage": "New message"
     },
+    "alex": {
+      "greeting": "Hey, want to try one quick fact-checking question?",
+      "chooseAnswer": "Choose one reply:",
+      "correctReply": "Nice catch. You earned {points} points.",
+      "incorrectReply": "Not quite. No points this time, but here is why."
+    },
     "onboarding": {
       "step1": {
         "greeting": "Hey! Welcome to the feed. I'm Paula, and I'll help you navigate this wild world of online information. 👋",


### PR DESCRIPTION
Description:
## Summary
- Add Alex chat page (`/chat/alex`) where users answer a multiple-choice fact-checking question
- Make Paula and Alex chat list items clickable, routing to their respective pages
- Add MCQ content type and `mcq-1` question content to support the Alex chat flow

## Changes
- `chat/alpage with
Description:
## Summary
- Add Alex chat page (`/chat/alex`) where users answer a multiple-choice fact-checking question
- Make Paulickable,routing to their respective pages
- Add MCQ tion content to support the Alex chat flow

## Changes
- `chat/alex/page.tsx` — new Alex chat page with MCQ interaction
- `chat/page.tsx` — chat list items are now links (Paula → onboarding, Alex → /chat/alex)
- `chat/_clex userentry
- `content`ContentType.MCQ`, `MCQContent` type, and `mcq-1`
content
- `contents/en/post/mcq-1-*` — MCQ question and feedback markdown files
- `i18n/ro` route forall locales
- `messages/en.json` — added `chat.alex` translation strings

## Notes
- Only Engd; otherlocales can be added later
- Example ed and canbe updated in the future
