### PR TITLE
fix: remove Analytics, Share, and Profile nav items from UI

### DIFF
--- a/src/__tests__/components/navigation-bar.test.tsx
+++ b/src/__tests__/components/navigation-bar.test.tsx
@@ -24,13 +24,11 @@ describe('Navigation', () => {
 
     it('renders all navigation items', () => {
       render(<Navigation />);
-      // Translation mock returns keys, so we check for lowercase
-      // Use getAllByText since items appear in both desktop and mobile
       expect(screen.getAllByText(/home/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/chat/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/analytics/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/share/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/profile/i).length).toBeGreaterThan(0);
+      expect(screen.queryAllByText(/analytics/i).length).toBe(0);
+      expect(screen.queryAllByText(/share/i).length).toBe(0);
+      expect(screen.queryAllByText(/profile/i).length).toBe(0);
     });
 
     it('highlights active navigation item', () => {
@@ -85,14 +83,9 @@ describe('Navigation', () => {
       const chatLinks = screen.getAllByRole('link', { name: /chat/i });
       expect(chatLinks[0]).toHaveAttribute('href', '/chat');
 
-      const analyticsLinks = screen.getAllByRole('link', { name: /analytics/i });
-      expect(analyticsLinks[0]).toHaveAttribute('href', '/analytics');
-
-      const shareLinks = screen.getAllByRole('link', { name: /share/i });
-      expect(shareLinks[0]).toHaveAttribute('href', '/share');
-
-      const profileLinks = screen.getAllByRole('link', { name: /profile/i });
-      expect(profileLinks[0]).toHaveAttribute('href', '/profile');
+      expect(screen.queryAllByRole('link', { name: /analytics/i }).length).toBe(0);
+      expect(screen.queryAllByRole('link', { name: /share/i }).length).toBe(0);
+      expect(screen.queryAllByRole('link', { name: /profile/i }).length).toBe(0);
     });
 
     it('renders icons for each navigation item', () => {
@@ -119,9 +112,9 @@ describe('Navigation', () => {
       render(<Navigation />);
       expect(screen.getAllByText(/home/i).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/chat/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/analytics/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/share/i).length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/profile/i).length).toBeGreaterThan(0);
+      expect(screen.queryAllByText(/analytics/i).length).toBe(0);
+      expect(screen.queryAllByText(/share/i).length).toBe(0);
+      expect(screen.queryAllByText(/profile/i).length).toBe(0);
     });
 
     it('has correct mobile navigation positioning', () => {
@@ -132,11 +125,11 @@ describe('Navigation', () => {
     });
 
     it('highlights active item in mobile view', () => {
-      mockUsePathname.mockReturnValue('/analytics');
+      mockUsePathname.mockReturnValue('/chat');
       render(<Navigation />);
 
-      const analyticsLinks = screen.getAllByText(/analytics/i);
-      const activeLink = analyticsLinks.find((link) =>
+      const chatLinks = screen.getAllByText(/chat/i);
+      const activeLink = chatLinks.find((link) =>
         link.closest('a')?.classList.contains('text-(--color-ifrc-red)')
       );
       expect(activeLink).toBeDefined();

--- a/src/components/navigation-bar.tsx
+++ b/src/components/navigation-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import { Link, routing, usePathname } from '@/i18n/routing';
-import { Home, MessageSquare, PieChart, Upload, User } from 'lucide-react';
+import { Home, MessageSquare } from 'lucide-react';
 
 interface NavItem {
   href: keyof typeof routing.pathnames;
@@ -27,24 +27,6 @@ export default function Navigation() {
       labelKey: 'chat',
       icon: <MessageSquare size={24} strokeWidth={2} />,
       activeIcon: <MessageSquare size={24} fill="currentColor" strokeWidth={1} />,
-    },
-    {
-      href: '/analytics',
-      labelKey: 'analytics',
-      icon: <PieChart size={24} strokeWidth={2} />,
-      activeIcon: <PieChart size={24} fill="currentColor" strokeWidth={1} />,
-    },
-    {
-      href: '/share',
-      labelKey: 'share',
-      icon: <Upload size={24} strokeWidth={2} />,
-      activeIcon: <Upload size={24} fill="currentColor" strokeWidth={1} />,
-    },
-    {
-      href: '/profile',
-      labelKey: 'profile',
-      icon: <User size={24} strokeWidth={2} />,
-      activeIcon: <User size={24} fill="currentColor" strokeWidth={1} />,
     },
   ];
 


### PR DESCRIPTION
## Summary
- Remove Analytics, Share, and Profile icons from the navigation bar (desktop sidebar and mobile bottom nav)
- Home and Chat tabs remain

## Why
These pages are not required for the MVP and are temporarily hidden until needed.

## Changes
- `src/components/navigation-bar.tsx`, removed analytics, share, and profile entries from `navItems` and cleaned up unused icon imports